### PR TITLE
Support for Yarn 2.3+, other enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 
 test_files/*.csv
 test_files/*.yarnc
+ysc.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ csv = "1"
 intl_pluralrules = "7"
 log = "0.4"
 prost = "0.12"
+rand = { optional = true, version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 unic-langid = "0.9"
 
@@ -21,3 +22,7 @@ prost-build = "0.12"
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"
+
+[features]
+default = ["random"]
+random = ["rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ repository = "https://github.com/mystal/yharnam"
 csv = "1"
 intl_pluralrules = "7"
 log = "0.4"
-prost = "0.12.1"
+prost = "0.12"
 serde = { version = "1", features = ["derive"] }
 unic-langid = "0.9"
 
 [build-dependencies]
-prost-build = "0.12.1"
+prost-build = "0.12"
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ repository = "https://github.com/mystal/yharnam"
 csv = "1"
 intl_pluralrules = "7"
 log = "0.4"
-prost = "0.7"
+prost = "0.12.1"
 serde = { version = "1", features = ["derive"] }
 unic-langid = "0.9"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.12.1"
 
 [dev-dependencies]
-pretty_env_logger = "0.4"
+pretty_env_logger = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
 # Yharnam
 
+This is a fork of the original `yharnam` repository which updates the supported
+Yarn Spinner version to 2.3, and adds in additional methods and functions.
+
 A Rust implementation of the [Yarn Spinner] runtime. Currently it is only
 capable of running pre-compiled Yarn Spinner files. A parser for `.yarn` files
 is in progress.
 
-Currently targetting (and based on) Yarn Spinner
-[1.2.0](https://github.com/YarnSpinnerTool/YarnSpinner/releases/tag/v1.2.0).
+> **NOTE** to run tests you will need to download a copy of
+> [`ysc`](https://github.com/YarnSpinnerTool/YarnSpinner-Console), and use it to
+> compile each of the test `.yarn` files.
 
+Currently tested on Yarn Spinner
+[2.3.0](https://github.com/YarnSpinnerTool/YarnSpinner/releases/tag/v2.3.0).
 
 [Yarn Spinner]: https://yarnspinner.dev/
+
+## Features
+
+### random
+
+Use the `random` feature to enable random operations such as `dice`, `random`
+and `random_range`. An additional non-standard function `random_test` is
+provided. This takes a threshold between 0-1 and randomly generates a boolean
+based on whether a random number is above or below the threshold (see `gen_bool`
+from the `rand` crate).
+
+In addition the random generator can be supplied a seed by calling
+`vm.seed_random_generator(u64)`. See the random tests for an example.

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
-fn main() {
-    prost_build::compile_protos(
-        &["src/yarn_spinner.proto"],
-        &["src/"],
-    ).unwrap();
+use std::io::Result;
+
+fn main() -> Result<()> {
+    prost_build::compile_protos(&["src/yarn_spinner.proto"], &["src/"])?;
+
+    Ok(())
 }

--- a/src/bin/yarn-run.rs
+++ b/src/bin/yarn-run.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let mut selection = String::new();
                     io::stdin().read_line(&mut selection)?;
                     let selection: u32 = selection.trim().parse()?;
-                    vm.set_selected_option(selection);
+                    vm.set_selected_option(selection)?;
                 }
                 SuspendReason::Command(command_text) => {
                     println!("== Command: {} ==", command_text);

--- a/src/bin/yarn-run.rs
+++ b/src/bin/yarn-run.rs
@@ -70,8 +70,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                     let tags = tags_table
                         .iter()
-                        .find(|line_info| line_info.id == line.id)
-                        .map(|line_info| &line_info.tags)
+                        .find(|metadata_info| metadata_info.id == line.id)
+                        .map(|metadata_info| &metadata_info.tags)
                         .cloned()
                         .unwrap_or_else(|| Vec::new());
 

--- a/src/bin/yarn-run.rs
+++ b/src/bin/yarn-run.rs
@@ -45,11 +45,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut vm = VirtualMachine::new(program);
     if vm.program.nodes.contains_key(&start_node) {
         // Set the start node.
-        vm.set_node(&start_node);
+        vm.set_node(&start_node)?;
 
         // Start executing.
         loop {
-            match vm.continue_dialogue() {
+            match vm.continue_dialogue()? {
+                // Err(e) => return Err(Box::new(e)),
                 SuspendReason::Line(line) => {
                     let text = string_table
                         .iter()
@@ -91,6 +92,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                 SuspendReason::DialogueComplete(last_node) => {
                     println!("== Node end: {} ==", last_node);
                     println!("== Dialogue complete ==");
+                    break;
+                }
+                SuspendReason::InvalidOption(option_name) => {
+                    println!("INVALID OPTION: {option_name} is not an option. Please try again");
                     break;
                 }
             }

--- a/src/bin/yarn-run.rs
+++ b/src/bin/yarn-run.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Start executing.
         loop {
             match vm.continue_dialogue()? {
-                // Err(e) => return Err(Box::new(e)),
+                SuspendReason::Nop => {}
                 SuspendReason::Line(line) => {
                     let text = string_table
                         .iter()

--- a/src/bin/yarn-run.rs
+++ b/src/bin/yarn-run.rs
@@ -28,14 +28,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Load LineInfos from a csv file.
     let mut csv_path = proto_path;
-    println!(
-        "Changing filename from {:?} to {}",
-        csv_path.file_name(),
-        format!(
-            "{}-Lines.csv",
-            csv_path.file_stem().unwrap().to_str().unwrap()
-        )
-    );
 
     csv_path.set_file_name(format!(
         "{}-Lines.csv",

--- a/src/bin/yarn-run.rs
+++ b/src/bin/yarn-run.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .find(|metadata_info| metadata_info.id == line.id)
                         .map(|metadata_info| &metadata_info.tags)
                         .cloned()
-                        .unwrap_or_else(|| Vec::new());
+                        .unwrap_or_default();
 
                     if let Some(text) = text {
                         println!("{text}, tagged {tags:?}");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,31 @@
+use std::error::Error;
+
+#[derive(Debug)]
+pub enum VmError {
+    /// A general logic or configuration error
+    General(String),
+    /// A library function doesn't exist in the configured library
+    MissingLibraryFunction(String),
+    /// No operation occurred, this may or may not be expected
+    NoOperation,
+}
+
+impl std::fmt::Display for VmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "A Virtual Machine Error was encountered: {:?}", self)
+    }
+}
+
+impl Error for VmError {}
+
+impl From<String> for VmError {
+    fn from(message: String) -> Self {
+        Self::General(message)
+    }
+}
+
+impl From<&str> for VmError {
+    fn from(message: &str) -> Self {
+        Self::General(message.to_owned())
+    }
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -166,6 +166,16 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
     );
 
     library.insert(
+        "int".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            let sign = number.signum();
+
+            YarnValue::Number(number.abs().floor() * sign)
+        }),
+    );
+
+    library.insert(
         "decimal".to_string(),
         FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             let number = parameters[0].as_number();

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -8,84 +8,84 @@ use crate::{FunctionInfo, VirtualMachine, YarnValue};
 pub fn add_mathematical_functions(library: &mut HashMap<String, FunctionInfo>) {
     library.insert(
         "Add".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             parameters[0].add(&parameters[1]).unwrap()
         }),
     );
 
     library.insert(
         "Minus".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             parameters[0].sub(&parameters[1]).unwrap()
         }),
     );
 
     library.insert(
         "UnaryMinus".to_string(),
-        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             parameters[0].neg()
         }),
     );
 
     library.insert(
         "Divide".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             parameters[0].div(&parameters[1]).unwrap()
         }),
     );
 
     library.insert(
         "Multiply".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             parameters[0].mul(&parameters[1]).unwrap()
         }),
     );
 
     library.insert(
         "Modulo".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             parameters[0].rem(&parameters[1]).unwrap()
         }),
     );
 
     library.insert(
         "EqualTo".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0] == parameters[1]).into()
         }),
     );
 
     library.insert(
         "NotEqualTo".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0] != parameters[1]).into()
         }),
     );
 
     library.insert(
         "GreaterThan".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0] > parameters[1]).into()
         }),
     );
 
     library.insert(
         "GreaterThanOrEqualTo".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0] >= parameters[1]).into()
         }),
     );
 
     library.insert(
         "LessThan".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0] < parameters[1]).into()
         }),
     );
 
     library.insert(
         "LessThanOrEqualTo".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0] <= parameters[1]).into()
         }),
     );
@@ -95,28 +95,28 @@ pub fn add_mathematical_functions(library: &mut HashMap<String, FunctionInfo>) {
 pub fn add_logic_functions(library: &mut HashMap<String, FunctionInfo>) {
     library.insert(
         "And".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0].as_bool() && parameters[1].as_bool()).into()
         }),
     );
 
     library.insert(
         "Or".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0].as_bool() || parameters[1].as_bool()).into()
         }),
     );
 
     library.insert(
         "Xor".to_string(),
-        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (parameters[0].as_bool() ^ parameters[1].as_bool()).into()
         }),
     );
 
     library.insert(
         "Not".to_string(),
-        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (!parameters[0].as_bool()).into()
         }),
     );
@@ -126,7 +126,7 @@ pub fn add_logic_functions(library: &mut HashMap<String, FunctionInfo>) {
 pub fn add_visited_functions(library: &mut HashMap<String, FunctionInfo>) {
     library.insert(
         "visited".to_string(),
-        FunctionInfo::new_returning(1, &|vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (*vm.visit_counter
                 .get(&parameters[0].as_string())
                 .unwrap_or_else(|| &0)
@@ -137,7 +137,7 @@ pub fn add_visited_functions(library: &mut HashMap<String, FunctionInfo>) {
 
     library.insert(
         "visited_count".to_string(),
-        FunctionInfo::new_returning(1, &|vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             YarnValue::Number(
                 *vm.visit_counter
                     .get(&parameters[0].as_string())
@@ -151,7 +151,7 @@ pub fn add_visited_functions(library: &mut HashMap<String, FunctionInfo>) {
 pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>) {
     library.insert(
         "floor".to_string(),
-        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             let number = parameters[0].as_number();
             YarnValue::Number(number.floor())
         }),
@@ -159,7 +159,7 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
 
     library.insert(
         "ceil".to_string(),
-        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             let number = parameters[0].as_number();
             YarnValue::Number(number.ceil())
         }),
@@ -167,7 +167,7 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
 
     library.insert(
         "decimal".to_string(),
-        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             let number = parameters[0].as_number();
             YarnValue::Number(number.fract().abs())
         }),
@@ -175,7 +175,7 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
 
     library.insert(
         "dec".to_string(),
-        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             let number = parameters[0].as_number();
             YarnValue::Number(if number.floor() == number {
                 number - 1.
@@ -187,7 +187,7 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
 
     library.insert(
         "inc".to_string(),
-        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             let number = parameters[0].as_number();
             YarnValue::Number(if number.ceil() == number {
                 number + 1.
@@ -198,3 +198,39 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
     );
 }
 
+/// Adds random number functions
+#[cfg(feature = "random")]
+pub fn add_random_functions(library: &mut HashMap<String, FunctionInfo>) {
+    use rand::Rng;
+
+    library.insert(
+        "dice".to_string(),
+        FunctionInfo::new_returning(1, &|vm: &mut VirtualMachine, parameters: &[YarnValue]| {
+            YarnValue::Number(vm.rand.gen_range(1..=(parameters[0].as_number() as u32)) as f32)
+        }),
+    );
+
+    library.insert(
+        "random".to_string(),
+        FunctionInfo::new_returning(0, &|vm: &mut VirtualMachine, _parameters: &[YarnValue]| {
+            YarnValue::Number(vm.rand.gen::<f32>())
+        }),
+    );
+
+    library.insert(
+        "random_range".to_string(),
+        FunctionInfo::new_returning(2, &|vm: &mut VirtualMachine, parameters: &[YarnValue]| {
+            let a = parameters[0].as_number() as u32;
+            let b = parameters[1].as_number() as u32;
+            YarnValue::Number(vm.rand.gen_range(a..=b) as f32)
+        }),
+    );
+
+    library.insert(
+        "random_test".to_string(),
+        FunctionInfo::new_returning(1, &|vm: &mut VirtualMachine, parameters: &[YarnValue]| {
+            let threshold = parameters[0].as_number() as f64;
+            YarnValue::Bool(vm.rand.gen_bool(threshold))
+        }),
+    );
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -225,6 +225,16 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
             YarnValue::Number((number * multiplier).round() / multiplier)
         }),
     );
+
+    library.insert(
+        "clamp".to_string(),
+        FunctionInfo::new_returning(3, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            let clamp_min = parameters[1].as_number();
+            let clamp_max = parameters[2].as_number();
+            YarnValue::Number(number.clamp(clamp_min, clamp_max))
+        }),
+    );
 }
 
 /// Adds random number functions

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,0 +1,149 @@
+//! Contains functions that can be inserted into the library
+
+use std::collections::HashMap;
+
+use crate::{FunctionInfo, VirtualMachine, YarnValue};
+
+/// Adds mathemtical functions such as addition, subtraction and so on to the library.
+pub fn add_mathetmatical_functions(library: &mut HashMap<String, FunctionInfo>) {
+    library.insert(
+        "Add".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            parameters[0].add(&parameters[1]).unwrap()
+        }),
+    );
+
+    library.insert(
+        "Minus".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            parameters[0].sub(&parameters[1]).unwrap()
+        }),
+    );
+
+    library.insert(
+        "UnaryMinus".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            parameters[0].neg()
+        }),
+    );
+
+    library.insert(
+        "Divide".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            parameters[0].div(&parameters[1]).unwrap()
+        }),
+    );
+
+    library.insert(
+        "Multiply".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            parameters[0].mul(&parameters[1]).unwrap()
+        }),
+    );
+
+    library.insert(
+        "Modulo".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            parameters[0].rem(&parameters[1]).unwrap()
+        }),
+    );
+
+    library.insert(
+        "EqualTo".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0] == parameters[1]).into()
+        }),
+    );
+
+    library.insert(
+        "NotEqualTo".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0] != parameters[1]).into()
+        }),
+    );
+
+    library.insert(
+        "GreaterThan".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0] > parameters[1]).into()
+        }),
+    );
+
+    library.insert(
+        "GreaterThanOrEqualTo".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0] >= parameters[1]).into()
+        }),
+    );
+
+    library.insert(
+        "LessThan".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0] < parameters[1]).into()
+        }),
+    );
+
+    library.insert(
+        "LessThanOrEqualTo".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0] <= parameters[1]).into()
+        }),
+    );
+}
+
+/// Adds logic functions to the library, such as "and", "or" and so on.
+pub fn add_logic_functions(library: &mut HashMap<String, FunctionInfo>) {
+    library.insert(
+        "And".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0].as_bool() && parameters[1].as_bool()).into()
+        }),
+    );
+
+    library.insert(
+        "Or".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0].as_bool() || parameters[1].as_bool()).into()
+        }),
+    );
+
+    library.insert(
+        "Xor".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (parameters[0].as_bool() ^ parameters[1].as_bool()).into()
+        }),
+    );
+
+    library.insert(
+        "Not".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (!parameters[0].as_bool()).into()
+        }),
+    );
+}
+
+/// Adds functions such as "visited" and "visited_count" to the library
+pub fn add_visited_functions(library: &mut HashMap<String, FunctionInfo>) {
+    library.insert(
+        "visited".to_string(),
+        FunctionInfo::new_returning(1, &|vm: &VirtualMachine, parameters: &[YarnValue]| {
+            (*vm.visit_counter
+                .get(&parameters[0].as_string())
+                .unwrap_or_else(|| &0)
+                > 0)
+            .into()
+        }),
+    );
+
+    library.insert(
+        "visited_count".to_string(),
+        FunctionInfo::new_returning(1, &|vm: &VirtualMachine, parameters: &[YarnValue]| {
+            YarnValue::Number(
+                *vm.visit_counter
+                    .get(&parameters[0].as_string())
+                    .unwrap_or_else(|| &0) as f32,
+            )
+        }),
+    );
+}
+

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::{FunctionInfo, VirtualMachine, YarnValue};
 
-/// Adds mathemtical functions such as addition, subtraction and so on to the library.
-pub fn add_mathetmatical_functions(library: &mut HashMap<String, FunctionInfo>) {
+/// Adds mathematical functions such as addition, subtraction and so on to the library.
+pub fn add_mathematical_functions(library: &mut HashMap<String, FunctionInfo>) {
     library.insert(
         "Add".to_string(),
         FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
@@ -143,6 +143,57 @@ pub fn add_visited_functions(library: &mut HashMap<String, FunctionInfo>) {
                     .get(&parameters[0].as_string())
                     .unwrap_or_else(|| &0) as f32,
             )
+        }),
+    );
+}
+
+/// Adds function
+pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>) {
+    library.insert(
+        "floor".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            YarnValue::Number(number.floor())
+        }),
+    );
+
+    library.insert(
+        "ceil".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            YarnValue::Number(number.ceil())
+        }),
+    );
+
+    library.insert(
+        "decimal".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            YarnValue::Number(number.fract().abs())
+        }),
+    );
+
+    library.insert(
+        "dec".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            YarnValue::Number(if number.floor() == number {
+                number - 1.
+            } else {
+                number.floor()
+            })
+        }),
+    );
+
+    library.insert(
+        "inc".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            YarnValue::Number(if number.ceil() == number {
+                number + 1.
+            } else {
+                number.ceil()
+            })
         }),
     );
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -129,7 +129,7 @@ pub fn add_visited_functions(library: &mut HashMap<String, FunctionInfo>) {
         FunctionInfo::new_returning(1, &|vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             (*vm.visit_counter
                 .get(&parameters[0].as_string())
-                .unwrap_or_else(|| &0)
+                .unwrap_or(&0)
                 > 0)
             .into()
         }),
@@ -141,7 +141,7 @@ pub fn add_visited_functions(library: &mut HashMap<String, FunctionInfo>) {
             YarnValue::Number(
                 *vm.visit_counter
                     .get(&parameters[0].as_string())
-                    .unwrap_or_else(|| &0) as f32,
+                    .unwrap_or(&0) as f32,
             )
         }),
     );

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -196,6 +196,25 @@ pub fn add_number_utility_functions(library: &mut HashMap<String, FunctionInfo>)
             })
         }),
     );
+
+    library.insert(
+        "round".to_string(),
+        FunctionInfo::new_returning(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            YarnValue::Number(number.round())
+        }),
+    );
+
+    library.insert(
+        "round_places".to_string(),
+        FunctionInfo::new_returning(2, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
+            let number = parameters[0].as_number();
+            let num_places = parameters[1].as_number() as u32;
+            let multiplier = 10u32.pow(num_places) as f32;
+
+            YarnValue::Number((number * multiplier).round() / multiplier)
+        }),
+    );
 }
 
 /// Adds random number functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,10 @@ impl VirtualMachine {
     // Either Line, Options, Command, NodeStart?, NodeEnd?, DialogeEnd
     pub fn continue_dialogue(&mut self) -> Result<SuspendReason, VmError> {
         if self.state.current_node_name.is_empty() {
+            if self.execution_state == ExecutionState::Stopped {
+                return Ok(SuspendReason::DialogueComplete("".into()));
+            }
+
             return Err("Cannot continue running dialogue. No node has been selected.".into());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, convert::TryInto};
 
 use errors::VmError;
-use functions::{add_logic_functions, add_mathetmatical_functions, add_visited_functions};
+use functions::{add_logic_functions, add_mathematical_functions, add_visited_functions};
 use log::*;
 use serde::Deserialize;
 
@@ -194,7 +194,7 @@ impl VirtualMachine {
     pub fn new(program: Program) -> Self {
         let mut library = HashMap::new();
 
-        add_mathetmatical_functions(&mut library);
+        add_mathematical_functions(&mut library);
         add_logic_functions(&mut library);
         add_visited_functions(&mut library);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,15 @@ pub struct LineInfo {
     pub line_number: u32,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct MetadataInfo {
+    pub id: String,
+    pub node: String,
+    #[serde(rename = "lineNumber")]
+    pub line_number: u32,
+    pub tags: Vec<String>,
+}
+
 /// A line of dialogue, sent from the [`VirtualMachine`] to the game.
 ///
 /// When the game receives a `Line`, it should do the following things to prepare the line for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashMap, convert::TryInto};
 
 use errors::VmError;
+use functions::{add_logic_functions, add_mathetmatical_functions, add_visited_functions};
 use log::*;
 use serde::Deserialize;
 
@@ -13,6 +14,7 @@ pub mod yarn_proto {
 }
 
 pub mod errors;
+mod functions;
 mod utils;
 mod value;
 
@@ -191,139 +193,11 @@ pub struct VirtualMachine {
 impl VirtualMachine {
     pub fn new(program: Program) -> Self {
         let mut library = HashMap::new();
-        library.insert(
-            "Add".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                parameters[0].add(&parameters[1]).unwrap()
-            }),
-        );
 
-        library.insert(
-            "Minus".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                parameters[0].sub(&parameters[1]).unwrap()
-            }),
-        );
+        add_mathetmatical_functions(&mut library);
+        add_logic_functions(&mut library);
+        add_visited_functions(&mut library);
 
-        library.insert(
-            "UnaryMinus".to_string(),
-            FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                parameters[0].neg()
-            }),
-        );
-
-        library.insert(
-            "Divide".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                parameters[0].div(&parameters[1]).unwrap()
-            }),
-        );
-
-        library.insert(
-            "Multiply".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                parameters[0].mul(&parameters[1]).unwrap()
-            }),
-        );
-
-        library.insert(
-            "Modulo".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                parameters[0].rem(&parameters[1]).unwrap()
-            }),
-        );
-
-        library.insert(
-            "EqualTo".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0] == parameters[1]).into()
-            }),
-        );
-
-        library.insert(
-            "NotEqualTo".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0] != parameters[1]).into()
-            }),
-        );
-
-        library.insert(
-            "GreaterThan".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0] > parameters[1]).into()
-            }),
-        );
-
-        library.insert(
-            "GreaterThanOrEqualTo".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0] >= parameters[1]).into()
-            }),
-        );
-
-        library.insert(
-            "LessThan".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0] < parameters[1]).into()
-            }),
-        );
-
-        library.insert(
-            "LessThanOrEqualTo".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0] <= parameters[1]).into()
-            }),
-        );
-
-        library.insert(
-            "And".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0].as_bool() && parameters[1].as_bool()).into()
-            }),
-        );
-
-        library.insert(
-            "Or".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0].as_bool() || parameters[1].as_bool()).into()
-            }),
-        );
-
-        library.insert(
-            "Xor".to_string(),
-            FunctionInfo::new_returning(2, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (parameters[0].as_bool() ^ parameters[1].as_bool()).into()
-            }),
-        );
-
-        library.insert(
-            "Not".to_string(),
-            FunctionInfo::new_returning(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (!parameters[0].as_bool()).into()
-            }),
-        );
-
-        library.insert(
-            "visited".to_string(),
-            FunctionInfo::new_returning(1, &|vm: &VirtualMachine, parameters: &[YarnValue]| {
-                (*vm.visit_counter
-                    .get(&parameters[0].as_string())
-                    .unwrap_or_else(|| &0)
-                    > 0)
-                .into()
-            }),
-        );
-
-        library.insert(
-            "visited_count".to_string(),
-            FunctionInfo::new_returning(1, &|vm: &VirtualMachine, parameters: &[YarnValue]| {
-                YarnValue::Number(
-                    *vm.visit_counter
-                        .get(&parameters[0].as_string())
-                        .unwrap_or_else(|| &0) as f32,
-                )
-            }),
-        );
 
         Self {
             state: VmState::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,18 +375,15 @@ impl VirtualMachine {
         }
     }
 
-    pub fn set_selected_option(&mut self, selected_option_id: u32) {
+    pub fn set_selected_option(&mut self, selected_option_id: u32) -> Result<(), VmError> {
         let selected_option_id = selected_option_id as usize;
 
         if self.execution_state != ExecutionState::WaitingOnOptionSelection {
-            panic!();
-            // throw new DialogueException(@"SetSelectedOption was called, but Dialogue wasn't waiting for a selection.
-            // This method should only be called after the Dialogue is waiting for the user to select an option.");
+            return Err("set_selected_option was called, but Dialogue wasn't waiting for a selection. This method should only be called after the Dialogue is waiting for the user to select an option.".into());
         }
 
         if selected_option_id >= self.state.current_options.len() {
-            panic!();
-            // throw new ArgumentOutOfRangeException($"{selectedOptionID} is not a valid option ID (expected a number between 0 and {state.currentOptions.Count-1}.");
+            return Err(format!("{selected_option_id} is not a valid option ID (expected a number between 0 and {}.", self.state.current_options.len() - 1).into());
         }
 
         // We now know what number option was selected; push the
@@ -403,6 +400,8 @@ impl VirtualMachine {
         self.execution_state = ExecutionState::Suspended;
 
         debug!("Selected option: {}", selected_option_id);
+
+        Ok(())
     }
 
     fn run_instruction(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,10 @@ impl VirtualMachine {
                 // be on the stack. Pushes the function's return value,
                 // if it returns one.
                 if let Some(Value::StringValue(func_name)) = &instruction.operands[0].value {
-                    if let Some(function) = self.library.get(func_name) {
+                    // functions are, e.g. "Number.EqualTo", but we only want "EqualTo"
+                    let func_name = func_name.split(".").last().unwrap().to_owned();
+
+                    if let Some(function) = self.library.get(&func_name) {
                         let actual_param_count = self.state.stack.pop().unwrap().as_number() as u8;
 
                         // If a function is variadic, it takes as many parameters as it was given.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,7 +568,7 @@ impl VirtualMachine {
                 // if it returns one.
                 if let Some(Value::StringValue(func_name)) = &instruction.operands[0].value {
                     // functions are, e.g. "Number.EqualTo", but we only want "EqualTo"
-                    let func_name = func_name.split(".").last().unwrap().to_owned();
+                    let func_name = func_name.split('.').last().unwrap().to_owned();
 
                     // We need to `take` here as we borrow "self" when getting the FunctionInfo and
                     // therefore can't pass a mutable borrow into `function.func.call()`.

--- a/src/yarn_spinner.proto
+++ b/src/yarn_spinner.proto
@@ -118,7 +118,7 @@ message Instruction {
         
         // Calls a function in the client. Pops as many arguments as the
         // client indicates the function receives, and the result (if any)
-        // is pushed to the stack.		
+        // is pushed to the stack.
         // opA = string: name of the function
         CALL_FUNC = 12; 
         

--- a/src/yarn_spinner.proto
+++ b/src/yarn_spinner.proto
@@ -1,5 +1,5 @@
 // NOTE: Copied from the main YarnSpinner GitHub repository:
-// https://github.com/YarnSpinnerTool/YarnSpinner/blob/fb2d6db6fed226514c0654e06c90c53d5705460f/YarnSpinner/yarn_spinner.proto
+// https://github.com/YarnSpinnerTool/YarnSpinner/blob/20036dc8c6522f4dd448ee1c079a3b4b3255327b/YarnSpinner/yarn_spinner.proto
 
 syntax = "proto3";
 package Yarn;
@@ -7,136 +7,154 @@ package Yarn;
 // A complete Yarn program.
 message Program {
 
-	// The name of the program.
-	string name = 1;
-	
-	// The collection of nodes in this program.
+    // The name of the program.
+    string name = 1;
+    
+    // The collection of nodes in this program.
     map<string, Node> nodes = 2;   	
+    
+    // The collection of initial values for variables; if a PUSH_VARIABLE
+    // instruction is run, and the value is not found in the storage, this
+    // value will be used
+    map<string, Operand> initial_values = 3;
 }
 
 // A collection of instructions
 message Node {
-	// The name of this node.
-	string name = 1;
-	
-	// The list of instructions in this node.
+    // The name of this node.
+    string name = 1;
+    
+    // The list of instructions in this node.
     repeated Instruction instructions = 2;
 
     // A jump table, mapping the names of labels to positions in the
     // instructions list.
-	map<string, int32> labels = 3;
-	
-	// The tags associated with this node.
-	repeated string tags = 4;
+    map<string, int32> labels = 3;
+    
+    // The tags associated with this node.
+    repeated string tags = 4;
 
-	// the entry in the program's string table that contains the original
-	// text of this node; null if this is not available    
-	string sourceTextStringID = 5;
+    // the entry in the program's string table that contains the original
+    // text of this node; null if this is not available    
+    string sourceTextStringID = 5;
+
+    repeated Header headers = 6;
+}
+
+message Header {
+    string key = 1;
+    string value = 2;
 }
 
 // A single Yarn instruction.
 message Instruction {
 
-	// The operation that this instruction will perform.
-	OpCode opcode = 1;
+    // The operation that this instruction will perform.
+    OpCode opcode = 1;
 
-	// The list of operands, if any, that this instruction uses.
+    // The list of operands, if any, that this instruction uses.
     repeated Operand operands = 2;
 
-	// The type of instruction that this is.
+    // The type of instruction that this is.
     enum OpCode {
-		
-		// Jumps to a named position in the node.
-		// opA = string: label name
-		JUMP_TO = 0; 
-		
-		// Peeks a string from stack, and jumps to that named position in
-		// the node. 
-		// No operands.
-		JUMP = 1; 
-		
-		// Delivers a string ID to the client.
-		// opA = string: string ID
-		RUN_LINE = 2; 
-		
-		// Delivers a command to the client.
-		// opA = string: command text
-		RUN_COMMAND = 3; 
-		
-		// Adds an entry to the option list (see ShowOptions).
-		// opA = string: string ID for option to add
-		ADD_OPTION = 4; 
-		
-		// Presents the current list of options to the client, then clears
-		// the list. The most recently selected option will be on the top
-		// of the stack when execution resumes.
-		// No operands.
-		SHOW_OPTIONS = 5; 
-		
-		// Pushes a string onto the stack.
-		// opA = string: the string to push to the stack.
-		PUSH_STRING = 6; 
-		
-		// Pushes a floating point number onto the stack.
-		// opA = float: number to push to stack
-		PUSH_FLOAT = 7; 
-		
-		// Pushes a boolean onto the stack.
-		// opA = bool: the bool to push to stack
-		PUSH_BOOL = 8; 
-		
-		// Pushes a null value onto the stack.
-		// No operands.
-		PUSH_NULL = 9; 
-		
-		// Jumps to the named position in the the node, if the top of the
-		// stack is not null, zero or false.
-		// opA = string: label name 
-		JUMP_IF_FALSE = 10; 
-		
-		// Discards top of stack.
-		// No operands.
-		POP = 11; 
-		
-		// Calls a function in the client. Pops as many arguments as the
-		// client indicates the function receives, and the result (if any)
-		// is pushed to the stack.
-		
-		// opA = string: name of the function
-		CALL_FUNC = 12; 
-		
-		// Pushes the contents of a variable onto the stack.
-		// opA = name of variable 
-		PUSH_VARIABLE = 13; 
-		
-		// Stores the contents of the top of the stack in the named
-		// variable. 
-		// opA = name of variable
-		STORE_VARIABLE = 14; 
-		
-		// Stops execution of the program.
-		// No operands.
-		STOP = 15; 
-		
-		// Run the node whose name is at the top of the stack.
-		// No operands.
-		RUN_NODE = 16; 
+        
+        // Jumps to a named position in the node.
+        // opA = string: label name
+        JUMP_TO = 0; 
+        
+        // Peeks a string from stack, and jumps to that named position in
+        // the node. 
+        // No operands.
+        JUMP = 1; 
+        
+        // Delivers a string ID to the client.
+        // opA = string: string ID
+        RUN_LINE = 2; 
+        
+        // Delivers a command to the client.
+        // opA = string: command text
+        RUN_COMMAND = 3; 
+        
+        // Adds an entry to the option list (see ShowOptions).
+        // - opA = string: string ID for option to add
+        // - opB = string: destination to go to if this option is selected
+        // - opC = number: number of expressions on the stack to insert
+        //   into the line
+        // - opD = bool: whether the option has a condition on it (in which
+        //   case a value should be popped off the stack and used to signal
+        //   the game that the option should be not available)
+        ADD_OPTION = 4; 
+        
+        // Presents the current list of options to the client, then clears
+        // the list. The most recently selected option will be on the top
+        // of the stack when execution resumes.
+        // No operands.
+        SHOW_OPTIONS = 5; 
+        
+        // Pushes a string onto the stack.
+        // opA = string: the string to push to the stack.
+        PUSH_STRING = 6; 
+        
+        // Pushes a floating point number onto the stack.
+        // opA = float: number to push to stack
+        PUSH_FLOAT = 7; 
+        
+        // Pushes a boolean onto the stack.
+        // opA = bool: the bool to push to stack
+        PUSH_BOOL = 8; 
+        
+        // Pushes a null value onto the stack.
+        // No operands.
+        PUSH_NULL = 9; 
+        
+        // Jumps to the named position in the the node, if the top of the
+        // stack is not null, zero or false.
+        // opA = string: label name 
+        JUMP_IF_FALSE = 10; 
+        
+        // Discards top of stack.
+        // No operands.
+        POP = 11; 
+        
+        // Calls a function in the client. Pops as many arguments as the
+        // client indicates the function receives, and the result (if any)
+        // is pushed to the stack.		
+        // opA = string: name of the function
+        CALL_FUNC = 12; 
+        
+        // Pushes the contents of a variable onto the stack.
+        // opA = name of variable 
+        PUSH_VARIABLE = 13; 
+        
+        // Stores the contents of the top of the stack in the named
+        // variable. 
+        // opA = name of variable
+        STORE_VARIABLE = 14; 
+        
+        // Stops execution of the program.
+        // No operands.
+        STOP = 15; 
+        
+        // Pops a string off the top of the stack, and runs the node with
+        // that name.
+        // No operands.
+        RUN_NODE = 16; 
     }
 }
 
 // A value used by an Instruction.
 message Operand {
 
-	// The type of operand this is.
+    // The type of operand this is.
     oneof value {
-		
-		// A string.
-		string string_value = 1;
-		
-		// A boolean (true or false).
-		bool bool_value = 2;
+        
+        // A string.
+        string string_value = 1;
+        
+        // A boolean (true or false).
+        bool bool_value = 2;
 
-		// A floating point number.
-		float float_value = 3;
+        // A floating point number.
+        float float_value = 3;
     }
 }

--- a/test_files/Expressions.yarn
+++ b/test_files/Expressions.yarn
@@ -7,7 +7,7 @@ title: Start
 
 // Test unary operators
 
-<<call assert(!$test == false)>>
+// Not supported in yarn v2.3+: <<call assert(!$test == false)>>
 <<call assert(-$test == -1)>>
 <<call assert(-$test == 0 - 1)>>
 
@@ -23,6 +23,5 @@ title: Start
 // Test floating point math
 <<call assert(1 / 2 == 0.5)>>
 <<call assert(0.1 + 0.1 == 0.2)>>
-
 
 ===

--- a/test_files/FormatFunctions.testplan
+++ b/test_files/FormatFunctions.testplan
@@ -15,14 +15,3 @@ line: Ordinal: other
 line: other: other
 
 line: Mae: Wow, I came 3rd!
-
-option: other
-option: one
-option: one
-select: 1
-
-option: other
-option: one
-option: one
-select: 1
-

--- a/test_files/FormatFunctions.yarn
+++ b/test_files/FormatFunctions.yarn
@@ -3,63 +3,47 @@ title: Start
 
 // Case selection
 <<set $gender to "male">>
-Select: [select {$gender} male="male" female="female" other="other"]
+Select: [select "{$gender}" male="male" female="female" other="other"]
 
 <<set $gender to "female">>
-Select: [select {$gender} male="male" female="female" other="other"]
+Select: [select "{$gender}" male="male" female="female" other="other"]
 
 <<set $gender to "other">>
-Select: [select {$gender} male="male" female="female" other="other"]
+Select: [select "{$gender}" male="male" female="female" other="other"]
 
 // Cardinal pluralisation
 <<set $num to 1>>
-Plural: [plural {$num} one="one" two="two" few="few" many="many" other="other"]
+Plural: [plural "{$num}" one="one" two="two" few="few" many="many" other="other"]
 
 <<set $num to 2>>
-Plural: [plural {$num} one="one" two="two" few="few" many="many" other="other"]
+Plural: [plural "{$num}" one="one" two="two" few="few" many="many" other="other"]
 
 <<set $num to 3>>
-Plural: [plural {$num} one="one" two="two" few="few" many="many" other="other"]
+Plural: [plural "{$num}" one="one" two="two" few="few" many="many" other="other"]
 
 <<set $num to 4>>
-Plural: [plural {$num} one="one" two="two" few="few" many="many" other="other"]
+Plural: [plural "{$num}" one="one" two="two" few="few" many="many" other="other"]
 
 // Ordinal pluralisation
 <<set $ord to 1>>
-Ordinal: [ordinal {$ord} one="one" two="two" few="few" many="many" other="other"]
+Ordinal: [ordinal "{$ord}" one="one" two="two" few="few" many="many" other="other"]
 
 <<set $ord to 2>>
-Ordinal: [ordinal {$ord} one="one" two="two" few="few" many="many" other="other"]
+Ordinal: [ordinal "{$ord}" one="one" two="two" few="few" many="many" other="other"]
 
 <<set $ord to 3>>
-Ordinal: [ordinal {$ord} one="one" two="two" few="few" many="many" other="other"]
+Ordinal: [ordinal "{$ord}" one="one" two="two" few="few" many="many" other="other"]
 
 <<set $ord to 4>>
-Ordinal: [ordinal {$ord} one="one" two="two" few="few" many="many" other="other"]
+Ordinal: [ordinal "{$ord}" one="one" two="two" few="few" many="many" other="other"]
 
 <<set $gender to "other">>
 <<set $num to 1>>
 <<set $ord to 1>>
 
 // Value insertion
-[select {$gender} male="male: %" female="female: %" other="other: %"]
+[select "{$gender}" male="male: %" female="female: %" other="other: %"]
 
 <<set $race_position = 3>>
-Mae: Wow, I came [ordinal {$race_position} one="%st" two="%nd" few="%rd" other="%th"]!
-
-// Shortcut options
-
--> [select {$gender} male="male" female="female" other="other"]
--> [plural {$num} one="one" few="few" many="many" other="other"]
--> [ordinal {$ord} one="one" two="two" few="few" many="many" other="other"]
-
-// Regular options
-[[[select {$gender} male="male" female="female" other="other"]|Destination]]
-[[[plural {$num} one="one" few="few" many="many" other="other"]|Destination]]
-[[[ordinal {$ord} one="one" few="few" many="many" other="other"]|Destination]]
-
-===
-title: Destination
----
-// no-op
+Mae: Wow, I came [ordinal "{$race_position}" one="%st" two="%nd" few="%rd" other="%th"]!
 ===

--- a/test_files/Functions.yarn
+++ b/test_files/Functions.yarn
@@ -12,5 +12,5 @@ title: Start
 
 // function calls as parameters
 
-<<call assert(last_value(1, last_value(2,3)) == 3)>>
+<<call assert(last_value(1, 2, last_value(4,2,3)) == 3)>>
 ===

--- a/test_files/IfStatements.testplan
+++ b/test_files/IfStatements.testplan
@@ -2,4 +2,7 @@ line: Player: Hey, Sally.
 line: Sally: Oh! Hi.
 line: Sally: You snuck up on me.
 line: Sally: Don't do that.
+line: The following should show when its false
+line: Player: Hey.
+line: Sally: Hi.
 stop: 

--- a/test_files/IfStatements.yarn
+++ b/test_files/IfStatements.yarn
@@ -9,4 +9,16 @@ title: Start
     Player: Hey. #line:a8e70c
     Sally: Hi. #line:305cde
 <<endif>>
+
+The following should show when its false
+
+<<if false>>
+    Player: Hey, Sally. #line:794946
+    Sally: Oh! Hi. #line:2dc39c
+    Sally: You snuck up on me. #line:34de2e
+    Sally: Don't do that. #line:dcc2bd
+<<else>>
+    Player: Hey. #line:a8e70d
+    Sally: Hi. #line:305cdf
+<<endif>>
 ===

--- a/test_files/InlineExpressions.testplan
+++ b/test_files/InlineExpressions.testplan
@@ -3,7 +3,6 @@ line: Number: 1
 line: Expression: 2
 line: String: string
 line: Bool: True
-line: Null: null
 line: Variable: variable
 
 line: variable is great!
@@ -13,7 +12,6 @@ option: Shortcut Number: 1
 option: Shortcut Expression: 2
 option: Shortcut String: string
 option: Shortcut Bool: True
-option: Shortcut Null: null
 option: Shortcut Variable: variable
 select: 1
 
@@ -22,14 +20,4 @@ command: number 1
 command: expression 2
 command: string string
 command: bool True
-command: null null
 command: variable variable
-
-# regular options
-option: Regular Number: 1
-option: Regular Expression: 2
-option: Regular String: string
-option: Regular Bool: True
-option: Regular Null: null
-option: Regular Variable: variable
-select: 1

--- a/test_files/InlineExpressions.testplan
+++ b/test_files/InlineExpressions.testplan
@@ -13,6 +13,7 @@ option: Shortcut Expression: 2
 option: Shortcut String: string
 option: Shortcut Bool: True
 option: Shortcut Variable: variable
+tags: lastline
 select: 1
 
 # commands

--- a/test_files/InlineExpressions.yarn
+++ b/test_files/InlineExpressions.yarn
@@ -10,7 +10,6 @@ Number: {1}
 Expression: {1+1}
 String: {"string"}
 Bool: {true}
-Null: {null}
 Variable: {$var}
 
 // Lines with the expresion at the start (issue #243)
@@ -21,7 +20,6 @@ Variable: {$var}
 -> Shortcut Expression: {1+1}
 -> Shortcut String: {"string"}
 -> Shortcut Bool: {true}
--> Shortcut Null: {null}
 -> Shortcut Variable: {$var}
 
 // Commands
@@ -29,16 +27,7 @@ Variable: {$var}
 <<expression {1+1}>>
 <<string {"string"}>>
 <<bool {true}>>
-<<null {null}>>
 <<variable {$var}>>
-
-// Regular Options
-[[Regular Number: {1}|Destination]]
-[[Regular Expression: {1+1}|Destination]]
-[[Regular String: {"string"}|Destination]]
-[[Regular Bool: {true}|Destination]]
-[[Regular Null: {null}|Destination]]
-[[Regular Variable: {$var}|Destination]]
 
 ===
 title: Destination

--- a/test_files/NumberFunctions.testplan
+++ b/test_files/NumberFunctions.testplan
@@ -30,3 +30,15 @@ line: round 10.5 = 11
 line: round_places 10.155 to 2 places = 10.16
 line: round_places 10.955 to 0 places = 11
 line: round_places 10.50011 to 4 places = 10.5001
+
+line: clamp 1 (2->4) = 2
+line: clamp 2 (2->4) = 2
+line: clamp 3 (2->4) = 3
+line: clamp 4 (2->4) = 4
+line: clamp 5 (2->4) = 4
+
+line: clampf 1.0 (2.1->2.9) = 2.1
+line: clampf 2.1 (2.1->2.9) = 2.1
+line: clampf 2.4 (2.1->2.9) = 2.4
+line: clampf 2.9 (2.1->2.9) = 2.9
+line: clampf 3.0 (2.1->2.9) = 2.9

--- a/test_files/NumberFunctions.testplan
+++ b/test_files/NumberFunctions.testplan
@@ -13,3 +13,11 @@ line: dec 10.1 = 10
 
 line: inc 11.0 = 12
 line: inc 10.1 = 11
+
+line: round 10.1 = 10
+line: round 10.9 = 11
+line: round 10.5 = 11
+
+line: round_places 10.155 to 2 places = 10.16
+line: round_places 10.955 to 0 places = 11
+line: round_places 10.50011 to 4 places = 10.5001

--- a/test_files/NumberFunctions.testplan
+++ b/test_files/NumberFunctions.testplan
@@ -1,0 +1,15 @@
+line: floor 1.1 = 1
+line: floor 2.0 = 2
+
+line: ceil 1.1 = 2
+line: ceil 2.0 = 2
+
+# float precision makes these tricky without further functions, skipping tests for now
+# line: decimal 1.353 = 0.353
+# line: decimal -1.554 = 0.554
+
+line: dec 10.0 = 9
+line: dec 10.1 = 10
+
+line: inc 11.0 = 12
+line: inc 10.1 = 11

--- a/test_files/NumberFunctions.testplan
+++ b/test_files/NumberFunctions.testplan
@@ -1,10 +1,19 @@
 line: floor 1.1 = 1
 line: floor 2.0 = 2
+line: floor -1.1 = -2
+line: floor -2.0 = -2
 
 line: ceil 1.1 = 2
 line: ceil 2.0 = 2
+line: ceil -1.1 = -1
+line: ceil -2.0 = -2
 
-# float precision makes these tricky without further functions, skipping tests for now
+line: int 1.1 = 1
+line: int 2.0 = 2
+line: int -1.1 = -1
+line: int -2.0 = -2
+
+# float precision makes these tricky, skipping tests for now
 # line: decimal 1.353 = 0.353
 # line: decimal -1.554 = 0.554
 

--- a/test_files/NumberFunctions.yarn
+++ b/test_files/NumberFunctions.yarn
@@ -33,4 +33,16 @@ round_places 10.155 to 2 places = {round_places(10.155, 2)}
 round_places 10.955 to 0 places = {round_places(10.955, 0)}
 round_places 10.50011 to 4 places = {round_places(10.50011, 4)}
 
+clamp 1 (2->4) = {clamp(1, 2, 4)}
+clamp 2 (2->4) = {clamp(2, 2, 4)}
+clamp 3 (2->4) = {clamp(3, 2, 4)}
+clamp 4 (2->4) = {clamp(4, 2, 4)}
+clamp 5 (2->4) = {clamp(5, 2, 4)}
+
+clampf 1.0 (2.1->2.9) = {clamp(1.0, 2.1, 2.9)}
+clampf 2.1 (2.1->2.9) = {clamp(2.1, 2.1, 2.9)}
+clampf 2.4 (2.1->2.9) = {clamp(2.4, 2.1, 2.9)}
+clampf 2.9 (2.1->2.9) = {clamp(2.9, 2.1, 2.9)}
+clampf 3.0 (2.1->2.9) = {clamp(3.0, 2.1, 2.9)}
+
 ===

--- a/test_files/NumberFunctions.yarn
+++ b/test_files/NumberFunctions.yarn
@@ -14,4 +14,12 @@ dec 10.0 = {dec(10.0)}
 dec 10.1 = {dec(10.1)}
 inc 11.0 = {inc(11.0)}
 inc 10.1 = {inc(10.1)}
+
+round 10.1 = {round(10.1)}
+round 10.9 = {round(10.9)}
+round 10.5 = {round(10.5)}
+
+round_places 10.155 to 2 places = {round_places(10.155, 2)}
+round_places 10.955 to 0 places = {round_places(10.955, 0)}
+round_places 10.50011 to 4 places = {round_places(10.50011, 4)}
 ===

--- a/test_files/NumberFunctions.yarn
+++ b/test_files/NumberFunctions.yarn
@@ -1,0 +1,17 @@
+title: Start
+---
+floor 1.1 = {floor(1.1)}
+floor 2.0 = {floor(2.0)}
+
+ceil 1.1 = {ceil(1.1)}
+ceil 2.0 = {ceil(2.0)}
+
+// float precision makes these tricky without further functions, skipping tests for now
+// decimal 1.353 = {decimal(1.353)}
+// decimal -1.554 = {decimal(-1.554)}
+
+dec 10.0 = {dec(10.0)}
+dec 10.1 = {dec(10.1)}
+inc 11.0 = {inc(11.0)}
+inc 10.1 = {inc(10.1)}
+===

--- a/test_files/NumberFunctions.yarn
+++ b/test_files/NumberFunctions.yarn
@@ -2,9 +2,18 @@ title: Start
 ---
 floor 1.1 = {floor(1.1)}
 floor 2.0 = {floor(2.0)}
+floor -1.1 = {floor(-1.1)}
+floor -2.0 = {floor(-2.0)}
 
 ceil 1.1 = {ceil(1.1)}
 ceil 2.0 = {ceil(2.0)}
+ceil -1.1 = {ceil(-1.1)}
+ceil -2.0 = {ceil(-2.0)}
+
+int 1.1 = {int(1.1)}
+int 2.0 = {int(2.0)}
+int -1.1 = {int(-1.1)}
+int -2.0 = {int(-2.0)}
 
 // float precision makes these tricky without further functions, skipping tests for now
 // decimal 1.353 = {decimal(1.353)}
@@ -12,6 +21,7 @@ ceil 2.0 = {ceil(2.0)}
 
 dec 10.0 = {dec(10.0)}
 dec 10.1 = {dec(10.1)}
+
 inc 11.0 = {inc(11.0)}
 inc 10.1 = {inc(10.1)}
 
@@ -22,4 +32,5 @@ round 10.5 = {round(10.5)}
 round_places 10.155 to 2 places = {round_places(10.155, 2)}
 round_places 10.955 to 0 places = {round_places(10.955, 0)}
 round_places 10.50011 to 4 places = {round_places(10.50011, 4)}
+
 ===

--- a/test_files/RandomFunctions.testplan
+++ b/test_files/RandomFunctions.testplan
@@ -16,3 +16,11 @@ line: random_test false
 line: random_test false
 line: random_test true
 line: random_test false
+
+option: Option 0
+option: Option 1
+option: Option 5
+option: Option 6
+select: 3
+line: Option 5 line should appear
+line: This is the end

--- a/test_files/RandomFunctions.testplan
+++ b/test_files/RandomFunctions.testplan
@@ -1,0 +1,18 @@
+# this should be repeatable because we seed the RNG in the test setup
+
+line: dice 4
+line: dice 6
+
+line: random 0.8831156
+line: random 0.65193355
+line: random 0.5465919
+
+line: random_range 84
+line: random_range 101
+line: random_range 33
+line: random_range 58
+
+line: random_test false
+line: random_test false
+line: random_test true
+line: random_test false

--- a/test_files/RandomFunctions.yarn
+++ b/test_files/RandomFunctions.yarn
@@ -1,0 +1,39 @@
+title: Start
+---
+dice {dice(6)}
+dice {dice(6)}
+
+random {random()}
+random {random()}
+random {random()}
+
+random_range {random_range(70, 120)}
+random_range {random_range(70, 120)}
+random_range {random_range(7, 65)}
+random_range {random_range(7, 65)}
+
+<<if random_test(0.5)>>
+random_test true
+<<else>>
+random_test false
+<<endif>>
+
+<<if random_test(0.5)>>
+random_test true
+<<else>>
+random_test false
+<<endif>>
+
+<<if random_test(0.995)>>
+random_test true
+<<else>>
+random_test false
+<<endif>>
+
+<<if random_test(0.005)>>
+random_test true
+<<else>>
+random_test false
+<<endif>>
+
+===

--- a/test_files/RandomFunctions.yarn
+++ b/test_files/RandomFunctions.yarn
@@ -36,4 +36,20 @@ random_test true
 random_test false
 <<endif>>
 
+-> Option 0
+    This line should not appear
+-> Option 1 <<if random_test(0.5)>>
+    This line should not appear
+-> Option 2 <<if random_test(0.5)>>
+    This line should not appear
+-> Option 3 <<if random_test(0.5)>>
+    This line should not appear
+-> Option 4 <<if random_test(0.5)>>
+    This line should not appear
+-> Option 5 <<if random_test(0.5)>>
+    Option 5 line should appear
+-> Option 6
+    This line should not appear
+
+This is the end
 ===

--- a/test_files/ShortcutOptions.testplan
+++ b/test_files/ShortcutOptions.testplan
@@ -4,24 +4,28 @@ select: 1
 line: This line should appear.
 option: Sub Option 1
 option: Sub Option 2
+tags: lastline
 select: 1
 line: This line should also appear.
 
 line: Bea: line text
 option: option1
 option: option2
+tags: lastline
 select: 1
 line: Bea: line text2
 
 line: Bea: indented line text
 option: indented option1
 option: indented option2
+tags: lastline
 select: 1
 line: Bea: indented line text2
 
 line: Bea: line text
 option: indented option1 following unindented line
 option: indented option2 following unindented line
+tags: lastline
 select: 1
 
 option: Option A
@@ -31,6 +35,7 @@ select: 1
 line: (Break up the commands)
 
 option: Option A
+tags: lastline
 option: Option B
 select: 1
 

--- a/test_files/Smileys.testplan
+++ b/test_files/Smileys.testplan
@@ -44,6 +44,7 @@ option: Mae: / \
 option: Mae: \ /
 option: Mae: ~~
 
+tags: lastline
 select: 1
 
 line: Separating the option groups here.
@@ -71,4 +72,5 @@ option: Mae: / \
 option: Mae: \ /
 option: Mae: ~~
 
+tags: lastline
 select: 1

--- a/test_files/Smileys.yarn
+++ b/test_files/Smileys.yarn
@@ -3,13 +3,13 @@ title: Start
 // Testing smileys
 
 
-Mae: ¯\_(ツ)_/¯
+Mae: ¯\\_(ツ)_/¯
 Mae: <o>
 Mae: :|
 Mae: :)
 Mae: :(
 Mae: :o
-Mae: :\
+Mae: :\\
 Mae: :<
 Mae: D:
 Mae: -_-
@@ -17,26 +17,26 @@ Mae: =_=
 Mae: U_U
 Mae: O_O
 Mae: o_o
-Mae: \o/
-Mae: /o\
+Mae: \\o/
+Mae: /o\\
 Mae: o/
 Mae: _o_
 Mae: o>
-Mae: / \
-Mae: \ /
+Mae: / \\
+Mae: \\ /
 Mae: ~~
 
 // Testing in an option group
 
 
 
--> Mae: ¯\_(ツ)_/¯
+-> Mae: ¯\\_(ツ)_/¯
 -> Mae: <o>
 -> Mae: :|
 -> Mae: :)
 -> Mae: :(
 -> Mae: :o
--> Mae: :\
+-> Mae: :\\
 -> Mae: :<
 -> Mae: D:
 -> Mae: -_-
@@ -44,13 +44,13 @@ Mae: ~~
 -> Mae: U_U
 -> Mae: O_O
 -> Mae: o_o
--> Mae: \o/
--> Mae: /o\
+-> Mae: \\o/
+-> Mae: /o\\
 -> Mae: o/
 -> Mae: _o_
 -> Mae: o>
--> Mae: / \
--> Mae: \ /
+-> Mae: / \\
+-> Mae: \\ /
 -> Mae: ~~
 
 Separating the option groups here.
@@ -58,13 +58,13 @@ Separating the option groups here.
 // Testing in an option group, with conditionals
 
 
--> Mae: ¯\_(ツ)_/¯ <<if true>>
+-> Mae: ¯\\_(ツ)_/¯ <<if true>>
 -> Mae: <o> <<if true>>
 -> Mae: :| <<if true>>
 -> Mae: :) <<if true>>
 -> Mae: :( <<if true>>
 -> Mae: :o <<if true>>
--> Mae: :\ <<if true>>
+-> Mae: :\\ <<if true>>
 -> Mae: :< <<if true>>
 -> Mae: D: <<if true>>
 -> Mae: -_- <<if true>>
@@ -72,12 +72,12 @@ Separating the option groups here.
 -> Mae: U_U <<if true>>
 -> Mae: O_O <<if true>>
 -> Mae: o_o <<if true>>
--> Mae: \o/ <<if true>>
--> Mae: /o\ <<if true>>
+-> Mae: \\o/ <<if true>>
+-> Mae: /o\\ <<if true>>
 -> Mae: o/ <<if true>>
 -> Mae: _o_ <<if true>>
 -> Mae: o> <<if true>>
--> Mae: / \ <<if true>>
--> Mae: \ / <<if true>>
+-> Mae: / \\ <<if true>>
+-> Mae: \\ / <<if true>>
 -> Mae: ~~ <<if true>>
 ===

--- a/test_files/Tags.testplan
+++ b/test_files/Tags.testplan
@@ -1,0 +1,7 @@
+line: This line has no tags
+line: This line has one tag
+tags: tag
+line: This line has three tags
+tags: tag1 tag2 tag3
+line: This line has one tag with a comma in the tag
+tags: tag1,tag2

--- a/test_files/Tags.yarn
+++ b/test_files/Tags.yarn
@@ -1,0 +1,9 @@
+title: Start
+---
+// Tests that tags are correctly parsed from the Metadata CSV file
+
+This line has no tags
+This line has one tag #tag
+This line has three tags #tag1 #tag2 #tag3
+This line has one tag with a comma in the tag #tag1,tag2
+===

--- a/test_files/Types.yarn
+++ b/test_files/Types.yarn
@@ -5,14 +5,8 @@ title: Start
 // string equality
 <<call assert("test" == "test")>>
 
-// string-number inequality
-<<call assert("test" != 1)>>
-
 // string case sensitivity
 <<call assert("hi" != "HI")>>
-
-// multiple-type concatenation
-<<call assert(1+1+"hi" == "2hi")>>
 
 // gt test
 <<call assert(3 gt 2)>>

--- a/test_files/VariableStorage.yarn
+++ b/test_files/VariableStorage.yarn
@@ -14,13 +14,8 @@ title: Start
 <<call assert($foo == -1)>>
 
 // Test string storage
-<<set $foo to "foo">>
-<<call assert($foo == "foo")>>
-
-<<set $foo to null>>
-
-// Test null storage
-<<call assert($foo == null)>>
+<<set $foo_str to "foo">>
+<<call assert($foo_str == "foo")>>
 
 // Test immediate value arithmetic
 <<set $foo = 45>>
@@ -98,16 +93,16 @@ title: Start
 <<call assert($foounused == 1)>>
 
 // Testing string addition
-<<set $foo = "foo">>
-<<set $bar = "bar">>
-<<set $foobar = $foo + "bar">>
+<<set $foo_str = "foo">>
+<<set $bar_str = "bar">>
+<<set $foobar_str = $foo_str + "bar">>
 
 // "Test immediate string addition
-<<call assert($foobar == "foobar")>>
+<<call assert($foobar_str == "foobar")>>
 
-<<set $foobar = $foo + $bar>>
+<<set $foobar_str = $foo_str + $bar_str>>
 
 // "Test string addition
-<<call assert($foobar == "foobar")>>
+<<call assert($foobar_str == "foobar")>>
 
 ===

--- a/test_files/VisitedCounter.testplan
+++ b/test_files/VisitedCounter.testplan
@@ -1,0 +1,2 @@
+line: Has not visited Other (0)
+line: Has visited Other (1)

--- a/test_files/VisitedCounter.yarn
+++ b/test_files/VisitedCounter.yarn
@@ -1,0 +1,29 @@
+title: Start
+---
+// Function tests
+
+// "add_three_operands" is a function that adds three operands together
+<<declare $has_visited = false>>
+<<set $has_visited to visited("Other")>>
+<<declare $visited_count = 0>>
+<<set $visited_count to visited_count("Other")>>
+
+<<if $has_visited>>
+Has visited Other ({$visited_count})
+<<else>>
+Has not visited Other ({$visited_count})
+<<endif>>
+
+<<jump Other>>
+===
+title: Other
+---
+<<set $has_visited to visited("Other")>>
+<<set $visited_count to visited_count("Other")>>
+
+<<if $has_visited>>
+Has visited Other ({$visited_count})
+<<else>>
+Has not visited Other ({$visited_count})
+<<endif>>
+===

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -64,7 +64,7 @@ fn test_commands() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_expressions() -> Result<(), Box<dyn Error>> {
-    let mut vm = set_up_vm("test_files/Expressions.yarn.yarnc");
+    let mut vm = set_up_vm("test_files/Expressions.yarnc");
 
     vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {
@@ -82,7 +82,7 @@ fn test_format_functions() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_functions() -> Result<(), Box<dyn Error>> {
-    let mut vm = set_up_vm("test_files/Functions.yarn.yarnc");
+    let mut vm = set_up_vm("test_files/Functions.yarnc");
 
     vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {
@@ -118,7 +118,7 @@ fn test_smileys() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_types() -> Result<(), Box<dyn Error>> {
-    let mut vm = set_up_vm("test_files/Types.yarn.yarnc");
+    let mut vm = set_up_vm("test_files/Types.yarnc");
 
     vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {
@@ -130,7 +130,7 @@ fn test_types() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_variable_storage() -> Result<(), Box<dyn Error>> {
-    let mut vm = set_up_vm("test_files/VariableStorage.yarn.yarnc");
+    let mut vm = set_up_vm("test_files/VariableStorage.yarnc");
 
     vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -117,6 +117,12 @@ fn test_smileys() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_tags() -> Result<(), Box<dyn Error>> {
+    let mut runner = test_plan::PlanRunner::new("test_files/Tags.yarn");
+    runner.run()
+}
+
+#[test]
 fn test_types() -> Result<(), Box<dyn Error>> {
     let mut vm = set_up_vm("test_files/Types.yarnc");
 

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -33,7 +33,7 @@ fn set_up_vm(yarnc_path: &str) -> VirtualMachine {
     let mut vm = VirtualMachine::new(program);
     vm.library.insert(
         "assert".to_string(),
-        FunctionInfo::new(1, &|parameters: &[YarnValue]| {
+        FunctionInfo::new(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
             if !parameters[0].as_bool() {
                 assert!(false, "Assertion failed");
             }
@@ -41,14 +41,14 @@ fn set_up_vm(yarnc_path: &str) -> VirtualMachine {
     );
     vm.library.insert(
         "add_three_operands".to_string(),
-        FunctionInfo::new_returning(3, &|parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(3, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
             let res = parameters[0].add(&parameters[1]).unwrap();
             res.add(&parameters[2]).unwrap()
         }),
     );
     vm.library.insert(
         "last_value".to_string(),
-        FunctionInfo::new_returning(-1, &|parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(-1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
             parameters.last().unwrap().clone()
         }),
     );
@@ -144,4 +144,10 @@ fn test_variable_storage() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_visited_counter() -> Result<(), Box<dyn Error>> {
+    let mut runner = test_plan::PlanRunner::new("test_files/VisitedCounter.yarnc");
+    runner.run()
 }

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -33,7 +33,7 @@ fn set_up_vm(yarnc_path: &str) -> VirtualMachine {
     let mut vm = VirtualMachine::new(program);
     vm.library.insert(
         "assert".to_string(),
-        FunctionInfo::new(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             if !parameters[0].as_bool() {
                 assert!(false, "Assertion failed");
             }
@@ -41,14 +41,14 @@ fn set_up_vm(yarnc_path: &str) -> VirtualMachine {
     );
     vm.library.insert(
         "add_three_operands".to_string(),
-        FunctionInfo::new_returning(3, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(3, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             let res = parameters[0].add(&parameters[1]).unwrap();
             res.add(&parameters[2]).unwrap()
         }),
     );
     vm.library.insert(
         "last_value".to_string(),
-        FunctionInfo::new_returning(-1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+        FunctionInfo::new_returning(-1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
             parameters.last().unwrap().clone()
         }),
     );
@@ -77,6 +77,12 @@ fn test_expressions() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_format_functions() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/FormatFunctions.yarn");
+    runner.run()
+}
+
+#[test]
+fn test_number_functions() -> Result<(), Box<dyn Error>> {
+    let mut runner = test_plan::PlanRunner::new("test_files/NumberFunctions.yarn");
     runner.run()
 }
 

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -111,6 +111,13 @@ fn test_inline_expressions() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_random_functions() -> Result<(), Box<dyn Error>> {
+    let mut runner = test_plan::PlanRunner::new("test_files/RandomFunctions.yarn");
+    runner.get_vm().set_random_seed(12345);
+    runner.run()
+}
+
+#[test]
 fn test_shortcut_options() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/ShortcutOptions.yarn");
     runner.run()

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -13,17 +13,19 @@ fn set_up_vm(yarnc_path: &str) -> VirtualMachine {
     let proto_path = PathBuf::from(yarnc_path);
 
     // Read the file's bytes and load a Program.
-    let proto_data = fs::read(&proto_path)
-        .unwrap();
-    let program = Program::decode(&*proto_data)
-        .unwrap();
+    let proto_data = fs::read(&proto_path).unwrap();
+    let program = Program::decode(&*proto_data).unwrap();
 
     // Load LineInfos from a csv file.
     let mut csv_path = proto_path;
-    csv_path.set_extension("csv");
-    let mut csv_reader = csv::Reader::from_path(csv_path)
-        .unwrap();
-    let _string_table: Vec<LineInfo> = csv_reader.deserialize()
+    csv_path.set_file_name(format!(
+        "{}-Lines.csv",
+        csv_path.file_stem().unwrap().to_str().unwrap()
+    ));
+
+    let mut csv_reader = csv::Reader::from_path(csv_path).unwrap();
+    let _string_table: Vec<LineInfo> = csv_reader
+        .deserialize()
         .map(|result| result.unwrap())
         .collect();
 

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
 
@@ -56,77 +57,85 @@ fn set_up_vm(yarnc_path: &str) -> VirtualMachine {
 }
 
 #[test]
-fn test_commands() {
+fn test_commands() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/Commands.yarn");
-    runner.run();
+    runner.run()
 }
 
 #[test]
-fn test_expressions() {
+fn test_expressions() -> Result<(), Box<dyn Error>> {
     let mut vm = set_up_vm("test_files/Expressions.yarn.yarnc");
 
-    vm.set_node("Start");
+    vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {
-        vm.continue_dialogue();
+        vm.continue_dialogue()?;
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_format_functions() {
+fn test_format_functions() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/FormatFunctions.yarn");
-    runner.run();
+    runner.run()
 }
 
 #[test]
-fn test_functions() {
+fn test_functions() -> Result<(), Box<dyn Error>> {
     let mut vm = set_up_vm("test_files/Functions.yarn.yarnc");
 
-    vm.set_node("Start");
+    vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {
-        vm.continue_dialogue();
+        vm.continue_dialogue()?;
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_if_statements() {
+fn test_if_statements() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/IfStatements.yarn");
-    runner.run();
+    runner.run()
 }
 
 #[test]
-fn test_inline_expressions() {
+fn test_inline_expressions() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/InlineExpressions.yarn");
-    runner.run();
+    runner.run()
 }
 
 #[test]
-fn test_shortcut_options() {
+fn test_shortcut_options() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/ShortcutOptions.yarn");
-    runner.run();
+    runner.run()
 }
 
 #[test]
-fn test_smileys() {
+fn test_smileys() -> Result<(), Box<dyn Error>> {
     let mut runner = test_plan::PlanRunner::new("test_files/Smileys.yarn");
-    runner.run();
+    runner.run()
 }
 
 #[test]
-fn test_types() {
+fn test_types() -> Result<(), Box<dyn Error>> {
     let mut vm = set_up_vm("test_files/Types.yarn.yarnc");
 
-    vm.set_node("Start");
+    vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {
-        vm.continue_dialogue();
+        vm.continue_dialogue()?;
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_variable_storage() {
+fn test_variable_storage() -> Result<(), Box<dyn Error>> {
     let mut vm = set_up_vm("test_files/VariableStorage.yarn.yarnc");
 
-    vm.set_node("Start");
+    vm.set_node("Start")?;
     while vm.execution_state != ExecutionState::Stopped {
-        vm.continue_dialogue();
+        vm.continue_dialogue()?;
     }
+
+    Ok(())
 }

--- a/tests/test_plan/mod.rs
+++ b/tests/test_plan/mod.rs
@@ -120,7 +120,7 @@ impl PlanRunner {
     pub fn new(yarn_path: &str) -> Self {
         let yarn_path = Path::new(yarn_path);
 
-        let proto_path = yarn_path.with_extension("yarn.yarnc");
+        let proto_path = yarn_path.with_extension("yarnc");
 
         // Read the file's bytes and load a Program.
         let proto_data = fs::read(&proto_path).unwrap();
@@ -128,7 +128,10 @@ impl PlanRunner {
 
         // Load LineInfos from a csv file.
         let mut csv_path = proto_path;
-        csv_path.set_extension("csv");
+        csv_path.set_file_name(format!(
+            "{}-Lines.csv",
+            csv_path.file_stem().unwrap().to_str().unwrap()
+        ));
         let mut csv_reader = csv::Reader::from_path(csv_path).unwrap();
         let string_table: Vec<LineInfo> = csv_reader
             .deserialize()
@@ -179,6 +182,9 @@ impl PlanRunner {
                 SuspendReason::Line(line) => {
                     // Assert that the test plan expects this line.
                     self.plan.next();
+
+                    println!("PARSING {:?}", line);
+
                     let plan_step = self.plan.get_current_step().unwrap();
                     let line_text = self.get_composed_text_for_line(&line);
                     assert!(

--- a/tests/test_plan/mod.rs
+++ b/tests/test_plan/mod.rs
@@ -164,7 +164,7 @@ impl PlanRunner {
         let mut vm = VirtualMachine::new(program);
         vm.library.insert(
             "assert".to_string(),
-            FunctionInfo::new(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
+            FunctionInfo::new(1, &|_vm: &mut VirtualMachine, parameters: &[YarnValue]| {
                 if !parameters[0].as_bool() {
                     assert!(false, "Assertion failed");
                 }

--- a/tests/test_plan/mod.rs
+++ b/tests/test_plan/mod.rs
@@ -164,7 +164,7 @@ impl PlanRunner {
         let mut vm = VirtualMachine::new(program);
         vm.library.insert(
             "assert".to_string(),
-            FunctionInfo::new(1, &|parameters: &[YarnValue]| {
+            FunctionInfo::new(1, &|_vm: &VirtualMachine, parameters: &[YarnValue]| {
                 if !parameters[0].as_bool() {
                     assert!(false, "Assertion failed");
                 }

--- a/tests/test_plan/mod.rs
+++ b/tests/test_plan/mod.rs
@@ -183,6 +183,12 @@ impl PlanRunner {
         }
     }
 
+    /// Gets a mutable ref to the [VirtualMachine] so that it can be configured
+    /// for the test (for instance to seed the RNG).
+    pub fn get_vm(&mut self) -> &mut VirtualMachine {
+        &mut self.vm
+    }
+
     fn get_tags_for_line(&self, line: &Line) -> Vec<String> {
         self.metadata_table
             .iter()

--- a/tests/test_plan/mod.rs
+++ b/tests/test_plan/mod.rs
@@ -179,6 +179,7 @@ impl PlanRunner {
 
         loop {
             match self.vm.continue_dialogue()? {
+                SuspendReason::Nop => {}
                 SuspendReason::Line(line) => {
                     // Assert that the test plan expects this line.
                     self.plan.next();

--- a/tests/test_plan/mod.rs
+++ b/tests/test_plan/mod.rs
@@ -198,7 +198,7 @@ impl PlanRunner {
                         assert_eq!(option_text, *plan_option);
                     }
                     match plan_step {
-                        PlanStep::Select(i) => self.vm.set_selected_option(*i),
+                        PlanStep::Select(i) => self.vm.set_selected_option(*i)?,
                         step => panic!("Expected PlanStep::Select, got {:?}", step),
                     }
                 }


### PR DESCRIPTION
Thanks for the great library. 

I've been working on adding `yharnam` 2.x support, and filling a few gaps I found as I went along. I realise that you may not be maintaining the repo any more but thought I'd make a PR in case it was useful. Let me know if you would prefer not to take contributions and I can publish my fork separately :)

The changes in this PR include:

- Support Yarn Spinner 2.3, including updating all tests for 2.3 syntax.
- Update dependencies
- Update the proto file (no real changes)
- Return `Result` from a lot of internal functions instead of panics (potentially addresses #6?)
- Add support + tests for `visited` and `visited_count` built-in functions (requires passing the `VirtualMachine` to functions)
- Add support + tests for the built-in maths functions available in Yarn Spinner 2.3 
- Add support + tests for random functions behind a feature flag. The RNG can be randomly seeded or supplied with an optional seed for determinism.
- Add support + tests for line tags
- Add support + tests for optional options, e.g. `-> Option 1 <<if $my_var == true >>`

